### PR TITLE
✨ Add new function Update-CWMTimeEntry and Update-CWMTimeSheet

### DIFF
--- a/ConnectWiseManageAPI/Public/Time/TimeEntries/Update-CWMTimeEntry.ps1
+++ b/ConnectWiseManageAPI/Public/Time/TimeEntries/Update-CWMTimeEntry.ps1
@@ -1,0 +1,19 @@
+function Update-CWMTimeEntry {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '', Justification = 'Used by sub-function')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Alias('entryId')]
+        [int]$id,
+        [Parameter(Mandatory = $true)]
+        [validateset('add', 'replace', 'remove')]
+        [string]$Operation,
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        $Value
+    )
+
+    $Endpoint = "/time/entries/$($id)"
+    Invoke-CWMUpdateMaster -Arguments $PsBoundParameters -Endpoint $Endpoint
+}

--- a/ConnectWiseManageAPI/Public/Time/TimeSheets/Update-CWMTimeSheet.ps1
+++ b/ConnectWiseManageAPI/Public/Time/TimeSheets/Update-CWMTimeSheet.ps1
@@ -1,0 +1,35 @@
+function Update-CWMTimeSheet {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '', Justification = 'Used by sub-function')]
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Alias('sheetId')]
+        [int]$id,
+        [Parameter(ParameterSetName = "Reject")]
+        [switch]$Reject,
+        [Parameter(ParameterSetName = "Reverse")]
+        [switch]$Reverse,
+        [Parameter(ParameterSetName = "Submit")]
+        [switch]$Submit,
+        [Parameter(ParameterSetName = "Approve")]
+        [switch]$Approve,
+        [Parameter(ParameterSetName = "Approve")]
+        [validateset('DataEntry', 'Tier1Update', 'Tier2Update', 'Billing', 'Service', 'Project', 'MonthlySummary', 'SalesActivity', 'Schedule')]
+        [string]$ApprovalType
+    )
+
+    $Endpoint = "/time/sheets/$($id)"
+
+    if ($PsBoundParameters.ContainsKey('Approve')) {
+        $PsBoundParameters.Remove('Approve')
+        $Endpoint = $Endpoint + "/approve"
+    } elseif ($PsBoundParameters.ContainsKey('reject')) {
+        $Endpoint = $Endpoint + "/reject"
+    } elseif ($PsBoundParameters.ContainsKey('reverse')) {
+        $Endpoint = $Endpoint + "/reverse"
+    } else {
+        $Endpoint = $Endpoint + "/submit"
+    }
+
+    Invoke-CWMNewMaster -Arguments $PsBoundParameters -Endpoint $Endpoint
+}

--- a/Docs/Update-CWMTimeEntry.md
+++ b/Docs/Update-CWMTimeEntry.md
@@ -1,0 +1,156 @@
+---
+external help file: ConnectWiseManageAPI-help.xml
+Module Name: ConnectWiseManageAPI
+online version:
+schema: 2.0.0
+---
+
+# Update-CWMTimeEntry
+
+## SYNOPSIS
+This will update a time entry.
+
+## SYNTAX
+
+```
+Update-CWMTimeEntry [-id] <Int32> [-Operation] <String> [-Path] <String> [-Value] <Object> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+$UpdateParam = @{
+    ID = 1
+    Operation = 'replace'
+    Path = 'name'
+    Value = $NewName
+}
+Update-CWMTimeEntry @UpdateParam
+```
+
+### Example 2
+```powershell
+$UpdateParam = @{
+    ID = 1
+    Operation = 'replace'
+    Path = 'subType'
+    Value = ${id = 123}
+}
+Update-CWMTimeEntry @UpdateParam
+```
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Operation
+What you are doing with the value.
+replace, add, remove
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: add, replace, remove
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Path
+The value that you want to perform the operation on.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Value
+The value of the path.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -id
+{{ Fill id Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: entryId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[https://developer.connectwise.com/Products/Manage/REST#/TimeEntries](https://developer.connectwise.com/Products/Manage/REST#/TimeEntries)

--- a/Docs/Update-CWMTimeSheet.md
+++ b/Docs/Update-CWMTimeSheet.md
@@ -1,0 +1,157 @@
+---
+external help file: ConnectWiseManageAPI-help.xml
+Module Name: ConnectWiseManageAPI
+online version:
+schema: 2.0.0
+---
+
+# Update-CWMTimeSheet
+
+## SYNOPSIS
+This will update a timesheet.
+
+## SYNTAX
+
+### Reject
+```
+Update-CWMTimeSheet -id <Int32> [-Reject] [<CommonParameters>]
+```
+
+### Reverse
+```
+Update-CWMTimeSheet -id <Int32> [-Reverse] [<CommonParameters>]
+```
+
+### Submit
+```
+Update-CWMTimeSheet -id <Int32> [-Submit] [<CommonParameters>]
+```
+
+### Approve
+```
+Update-CWMTimeSheet -id <Int32> [-Approve] [-ApprovalType <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+{{ Fill in the Description }}
+
+## EXAMPLES
+
+### Example 1
+```powershell
+Update-CWMTimeSheet -id 1 -Submit
+```
+
+### Example 2
+```powershell
+Update-CWMTimeSheet -id 2 -Approve -ApprovalType 'Tier1Update'
+```
+
+## PARAMETERS
+
+### -ApprovalType
+The type of value you want to assign.
+
+```yaml
+Type: String
+Parameter Sets: Approve
+Aliases:
+Accepted values: DataEntry, Tier1Update, Tier2Update, Billing, Service, Project, MonthlySummary, SalesActivity, Schedule
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Approve
+Allows the 'ApprovalType' parameter to be used.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Approve
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Reject
+Rejects a timesheet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Reject
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Reverse
+Reverses a timesheet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Reverse
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Submit
+Submits a timesheet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Submit
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -id
+{{ Fill id Description }}
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: sheetId
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+## RELATED LINKS
+
+[https://developer.connectwise.com/Products/Manage/REST#/TimeSheets](https://developer.connectwise.com/Products/Manage/REST#/TimeSheets)


### PR DESCRIPTION
Adds the ability to update time entries and timesheets.

For timesheets, this would make the **Submit-CWMTimeSheet** function obsolete.
'Approve', 'Reject', 'Submit', and 'Reverse' are now bundled inside one cmdlet.