### PR TITLE
Fix Invoke-WebRequest behavior changes with PowerShell 7.

### DIFF
--- a/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
+++ b/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
@@ -42,7 +42,14 @@
         $prevProgressPreference = $global:ProgressPreference
         $global:ProgressPreference = 'SilentlyContinue'
 
-        $Result = Invoke-WebRequest @Arguments -UseBasicParsing
+        if ($psversiontable.psversion.major -ge 7){
+
+            $Result = Invoke-WebRequest @Arguments -UseBasicParsing -AllowInsecureRedirect
+        }
+
+        else{
+            $Result = Invoke-WebRequest @Arguments -UseBasicParsing
+        }
 
         $global:ProgressPreference = $prevProgressPreference
     }
@@ -122,8 +129,17 @@
         Write-Warning "Issue with request, status: $($Result.StatusCode) $($Result.StatusDescription)"
         Write-Warning "$($Retry)/$($MaxRetry) retries, waiting $($Wait)ms."
         Start-Sleep -Milliseconds $Wait
-        $Result = Invoke-WebRequest @Arguments -UseBasicParsing
+        if ($psversiontable.psversion.major -ge 7){
+
+            $Result = Invoke-WebRequest @Arguments -UseBasicParsing -AllowInsecureRedirect
+        }
+
+        else{
+            $Result = Invoke-WebRequest @Arguments -UseBasicParsing
+        }
+
     }
+    
     if ($Retry -ge $MaxRetry) {
         return Write-Error "Max retries hit. Status: $($Result.StatusCode) $($Result.StatusDescription)"
     }

--- a/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
+++ b/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
@@ -29,7 +29,7 @@
     $Arguments.Remove('Version')
 
     if (!$Arguments.SessionVariable) {
-        $Arguments.WebSession = $script:CWMServerConnection.Session 
+        $Arguments.WebSession = $script:CWMServerConnection.Session
     }
 
     # Check URI format
@@ -105,9 +105,9 @@
         }
 
         if ($ErrorMessage.Length -lt 1) {
-            $ErrorMessage = $_ 
+            $ErrorMessage = $_
         } else {
-            $ErrorMessage += $_.ScriptStackTrace 
+            $ErrorMessage += $_.ScriptStackTrace
         }
 
         return Write-Error ($ErrorMessage | Out-String)
@@ -132,7 +132,7 @@
         }
 
     }
-    
+
     if ($Retry -ge $MaxRetry) {
         return Write-Error "Max retries hit. Status: $($Result.StatusCode) $($Result.StatusDescription)"
     }

--- a/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
+++ b/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
@@ -21,15 +21,16 @@
             if ($Key -eq 'Accept' -and $Arguments.Version -and $Arguments.Version -ne $script:CWMServerConnection.Version) {
                 $Arguments.Headers.Accept = "application/vnd.connectwise.com+json; version=$($Arguments.Version)"
                 Write-Verbose "Version Passed: $($Arguments.Version)"
-            }
-            else {
+            } else {
                 $Arguments.Headers += @{$Key = $script:CWMServerConnection.Headers.$Key }
             }
         }
     }
     $Arguments.Remove('Version')
 
-    if (!$Arguments.SessionVariable) { $Arguments.WebSession = $script:CWMServerConnection.Session }
+    if (!$Arguments.SessionVariable) {
+        $Arguments.WebSession = $script:CWMServerConnection.Session 
+    }
 
     # Check URI format
     if ($Arguments.URI -notlike '*`?*' -and $Arguments.URI -like '*`&*') {
@@ -42,18 +43,14 @@
         $prevProgressPreference = $global:ProgressPreference
         $global:ProgressPreference = 'SilentlyContinue'
 
-        if ($psversiontable.psversion.major -ge 7){
-
+        if ($psversiontable.psversion.major -ge 7) {
             $Result = Invoke-WebRequest @Arguments -UseBasicParsing -AllowInsecureRedirect
-        }
-
-        else{
+        } else {
             $Result = Invoke-WebRequest @Arguments -UseBasicParsing
         }
 
         $global:ProgressPreference = $prevProgressPreference
-    }
-    catch {
+    } catch {
         $global:ProgressPreference = $prevProgressPreference
 
         # Start error message
@@ -66,8 +63,7 @@
                 $ErrorStream = $_.Exception.Response.GetResponseStream()
                 $Reader = New-Object System.IO.StreamReader($ErrorStream)
                 $script:ErrBody = $Reader.ReadToEnd() | ConvertFrom-Json
-            }
-            catch {
+            } catch {
                 $script:ErrBody = $_.Exception.Response.Content
             }
             $ErrBody = $script:ErrBody
@@ -77,8 +73,7 @@
                 if ($ErrBody.code -eq 'Unauthorized') {
                     $ErrorMessage += "-----> $($ErrBody.message)"
                     $ErrorMessage += "-----> Use 'Disconnect-CWM' or 'Connect-CWM -Force' to set new authentication."
-                }
-                elseif ($ErrBody.code -eq 'ConnectWiseApi') {
+                } elseif ($ErrBody.code -eq 'ConnectWiseApi') {
                     switch ($ErrBody.message) {
                         'UserNotAuthenticated' {
                             $ErrorMessage += "-----> $($ErrBody.message)"
@@ -89,13 +84,11 @@
                             $ErrorMessage += '-----> ^ Error has not been documented please report. ^'
                         }
                     }
-                }
-                else {
+                } else {
                     $ErrorMessage += "-----> $($ErrBody.message)"
                     $ErrorMessage += '-----> ^ Error has not been documented please report. ^'
                 }
-            }
-            elseif ($_.Exception.message) {
+            } elseif ($_.Exception.message) {
                 $ErrorMessage += 'An exception has been thrown.'
                 $ErrorMessage += "--> $($_.Exception.message)"
             }
@@ -111,8 +104,11 @@
             }
         }
 
-        if ($ErrorMessage.Length -lt 1) { $ErrorMessage = $_ }
-        else { $ErrorMessage += $_.ScriptStackTrace }
+        if ($ErrorMessage.Length -lt 1) {
+            $ErrorMessage = $_ 
+        } else {
+            $ErrorMessage += $_.ScriptStackTrace 
+        }
 
         return Write-Error ($ErrorMessage | Out-String)
     }
@@ -129,12 +125,9 @@
         Write-Warning "Issue with request, status: $($Result.StatusCode) $($Result.StatusDescription)"
         Write-Warning "$($Retry)/$($MaxRetry) retries, waiting $($Wait)ms."
         Start-Sleep -Milliseconds $Wait
-        if ($psversiontable.psversion.major -ge 7){
-
+        if ($psversiontable.psversion.major -ge 7) {
             $Result = Invoke-WebRequest @Arguments -UseBasicParsing -AllowInsecureRedirect
-        }
-
-        else{
+        } else {
             $Result = Invoke-WebRequest @Arguments -UseBasicParsing
         }
 


### PR DESCRIPTION
[PowerShell 7 changed the default behavior of Invoke-WebRequest.](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/differences-from-windows-powershell?view=powershell-7.4#changes-to-web-cmdlets) requiring a minor change when running in PS7 for some data to get returned when the API redirects to another URI for POST results (such as creating new tickets).
Other than some formatting changes, this just checks $PSVersionTable.PSVersion.Major -ge 7, and adds the -AllowInsecureRedirect parameter if needed.