### PR TITLE
Updated Invoke-CWMUpdateMaster to allow multiple Path update

### DIFF
--- a/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMUpdateMaster.ps1
+++ b/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMUpdateMaster.ps1
@@ -6,13 +6,34 @@
     )
 
     Write-Verbose $($Arguments.Value | Out-String)
-    $Body = @(
-        @{
-            op    = $Arguments.Operation.toLower()
-            path  = $Arguments.Path
-            value = $Arguments.Value
+    If ($Arguments.Path.Count -gt 1) {
+        $Body = @()
+        For ($i = 0; $i -lt $Arguments.Path.Count; $i++) {
+            If ($Arguments.Path[$i] -is [Array]) {
+                $Body += @{
+                    op    = $Arguments.Operation.toLower()
+                    path  = $($Arguments.Path[$i])
+                    value = @($($Arguments.Value[$i]))
+                }
+            } Else {
+                $Body += @{
+                    op    = $Arguments.Operation.toLower()
+                    path  = $($Arguments.Path[$i])
+                    value = $Arguments.Value[$i]
+                }
+                    
+            }
         }
-    )
+    } Else {
+        $Body = @(
+            @{
+                op    = $Arguments.Operation.toLower()
+                path  = $Arguments.Path
+                value = $Arguments.Value
+            }
+        )
+    }
+
     $Body = ConvertTo-Json $Body -Depth 100
     Write-Verbose $Body
 
@@ -23,6 +44,7 @@
         ContentType = 'application/json'
         Body        = $Body
     }
+
     if ($PSCmdlet.ShouldProcess($WebRequestArguments.URI, "Invoke-CWMUpdateMaster, with body:`r`n$Body`r`n")) {
         $Result = Invoke-CWMWebRequest -Arguments $WebRequestArguments
         if ($Result.content) {


### PR DESCRIPTION
Allows you to update multiple paths at once on a single object. For example, if you modify the Update-CWMTicket function so Path/Value aren't strictly [string], you can perform something like:

`Update-CWMTicket -id 1 -operation replace -path @('contact', 'status') -value @(@{id=100}, @{id=50})`

Which would update both the 'contact' to id=100 and 'status' to id=50, instead of doing both of these

`Update-CWMTicket -id 1 -operation replace -path 'contact' -value @{id=100}`
`Update-CWMTicket -id 1 -operation replace -path 'status' -value @{id=50}`

This is required for Picking and Shipping functions in order to do a pick, as you may require the Picking serialNumber, serialNumberIds, pickingQty.

It will send through a bulk {operation for path 1},{operation for path 2} to the server to update both at once.