### PR TITLE
Update Invoke-CWMWebRequest.ps1 to include -AllowInsecureRedirect

### DIFF
--- a/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
+++ b/ConnectWiseManageAPI/Private/Invoke/Invoke-CWMWebRequest.ps1
@@ -42,7 +42,7 @@
         $prevProgressPreference = $global:ProgressPreference
         $global:ProgressPreference = 'SilentlyContinue'
 
-        $Result = Invoke-WebRequest @Arguments -UseBasicParsing
+        $Result = Invoke-WebRequest @Arguments -UseBasicParsing -AllowInsecureRedirect
 
         $global:ProgressPreference = $prevProgressPreference
     }
@@ -122,7 +122,7 @@
         Write-Warning "Issue with request, status: $($Result.StatusCode) $($Result.StatusDescription)"
         Write-Warning "$($Retry)/$($MaxRetry) retries, waiting $($Wait)ms."
         Start-Sleep -Milliseconds $Wait
-        $Result = Invoke-WebRequest @Arguments -UseBasicParsing
+        $Result = Invoke-WebRequest @Arguments -UseBasicParsing -AllowInsecureRedirect
     }
     if ($Retry -ge $MaxRetry) {
         return Write-Error "Max retries hit. Status: $($Result.StatusCode) $($Result.StatusDescription)"


### PR DESCRIPTION
Adds -AllowInsecureRedirect to the Invoke-WebRequest to allow proper communication with the ConnectWise servers. I have not investigated this properly for security issues, however nothing seems to have changed on CW end but since the implementation of this in PowerShell it will no longer return ID's on New-CWM* commands, this will fix.

Fixes Issue #70